### PR TITLE
Added so that arguments are needed for fixing nvidia drivers

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -6,12 +6,18 @@ detect_distro() {
         . /etc/os-release
         echo "$ID"
     else
-        echo "unknown"
+        echo "Fix-my-nvidia can NOT detect current system"
     fi
 }
 
 # Update system packages
 update_system() {
+
+if [ -z "$1" ]; then
+    echo "No arguments found."
+    echo "Try running './script.sh ubuntu', or whatever distribution you have."
+    exit 1
+else
     case "$1" in
         ubuntu|debian)
             sudo apt update && sudo apt upgrade -y
@@ -27,10 +33,16 @@ update_system() {
             exit 1
             ;;
     esac
+fi
 }
 
 # Install necessary packages for building drivers and pciutils
 install_build_packages() {
+if [ -z "$1" ]; then
+    echo "No arguments found."
+    echo "Try running './script.sh ubuntu', or whatever distribution you have."
+    exit 1
+else
     case "$1" in
         ubuntu|debian)
             sudo apt install build-essential linux-headers-$(uname -r) pciutils -y
@@ -42,6 +54,7 @@ install_build_packages() {
             sudo pacman -S base-devel linux-headers pciutils --noconfirm
             ;;
     esac
+    fi
 }
 
 # Identify GPU
@@ -51,6 +64,11 @@ identify_gpu() {
 
 # Remove old drivers
 remove_old_drivers() {
+if [ -z "$1" ]; then
+    echo "No arguments found."
+    echo "Try running './script.sh ubuntu', or whatever distribution you have."
+    exit 1
+else
     case "$1" in
         ubuntu|debian)
             sudo apt remove --purge '^nvidia-.*' '^libnvidia-.*' '^xserver-xorg-video-nouveau' -y
@@ -62,10 +80,16 @@ remove_old_drivers() {
             sudo pacman -Rns nvidia nvidia-utils --noconfirm
             ;;
     esac
+fi
 }
 
 # Install NVIDIA drivers
 install_nvidia_drivers() {
+if [ -z "$1" ]; then
+    echo "No arguments found."
+    echo "Try running './script.sh ubuntu', or whatever distribution you have."
+    exit 1
+else
     case "$1" in
         ubuntu|debian)
             sudo add-apt-repository ppa:graphics-drivers/ppa -y
@@ -79,6 +103,7 @@ install_nvidia_drivers() {
             sudo pacman -S nvidia nvidia-utils --noconfirm
             ;;
     esac
+fi
 }
 
 # Generate Xorg configuration
@@ -87,22 +112,20 @@ configure_xorg() {
 }
 
 # Main script execution
-distro=$(detect_distro)
-
 echo "Updating system..."
-update_system "$distro"
+update_system "$1"
 
 echo "Installing build packages and pciutils..."
-install_build_packages "$distro"
+install_build_packages "$1"
 
 echo "Identifying GPU..."
 identify_gpu
 
 echo "Removing old drivers..."
-remove_old_drivers "$distro"
+remove_old_drivers "$1"
 
 echo "Installing NVIDIA drivers..."
-install_nvidia_drivers "$distro"
+install_nvidia_drivers "$1"
 
 echo "Configuring Xorg..."
 configure_xorg


### PR DESCRIPTION
Sometimes, scripts may detect incorrect linux distributions.
I think i want the user to provide arguments so that the script could get it correctly.